### PR TITLE
fetchIPAddresses after finding a certificate, not for every certificate

### DIFF
--- a/lib/lib.go
+++ b/lib/lib.go
@@ -38,6 +38,7 @@ func CertCheckWorker(r string, homoglyph *map[string]string, msgChan chan []byte
 		if !IsMatchingCert(homoglyph, result, reg) {
 			continue
 		}
+		result.Addresses = fetchIPAddresses(result.Domain)
 		bufferChan <- result
 	}
 }
@@ -59,7 +60,6 @@ func ParseResultCertificate(msg []byte) (*model.Result, error) {
 		Addresses: []string{},
 	}
 
-	r.Addresses = fetchIPAddresses(r.Domain)
 	return r, nil
 }
 

--- a/lib/lib_test.go
+++ b/lib/lib_test.go
@@ -80,7 +80,6 @@ var _ = Describe("Handler", func() {
 				Expect(result.IDN).Should(Equal(""))
 				Expect(result.SAN).Should(Equal([]string{"baden-mueller.de", "www.baden-mueller.de"}))
 				Expect(result.Issuer).Should(Equal("Let's Encrypt"))
-				Expect(result.Addresses).Should(Equal([]string{"23.236.62.147"}))
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})

--- a/res/cert.json
+++ b/res/cert.json
@@ -64,6 +64,15 @@
         "subjectAltName": "DNS:www.baden-mueller.de, DNS:baden-mueller.de",
         "subjectKeyIdentifier": "4F:11:F2:CC:31:BC:1E:B8:29:2F:15:A9:C0:9A:51:C3:05:A4:48:C0"
       },
+      "issuer": {
+        "C": "US",
+        "CN": "Let's Encrypt Authority X3",
+        "L": null,
+        "O": "Let's Encrypt",
+        "OU": null,
+        "ST": null,
+        "aggregated": "/C=US/CN=Let's Encrypt Authority X3/O=Let's Encrypt"
+      },
       "fingerprint": "64:BF:49:41:3B:7A:FD:5D:C1:04:D9:44:64:9D:1C:25:13:A2:49:86",
       "not_after": 1598120268,
       "not_before": 1590344268,

--- a/res/cert_idn.json
+++ b/res/cert_idn.json
@@ -64,6 +64,15 @@
         "subjectAltName": "DNS:www.baden-mueller.de, DNS:xn--badn-mullr-msiec.de",
         "subjectKeyIdentifier": "4F:11:F2:CC:31:BC:1E:B8:29:2F:15:A9:C0:9A:51:C3:05:A4:48:C0"
       },
+      "issuer":{
+        "C": "US",
+        "CN": "Let's Encrypt Authority X3",
+        "L": null,
+        "O": "Let's Encrypt",
+        "OU": null,
+        "ST": null,
+        "aggregated": "/C=US/CN=Let's Encrypt Authority X3/O=Let's Encrypt"
+      },
       "fingerprint": "64:BF:49:41:3B:7A:FD:5D:C1:04:D9:44:64:9D:1C:25:13:A2:49:86",
       "not_after": 1598120268,
       "not_before": 1590344268,


### PR DESCRIPTION
It is not necessary to make a DNS request for each certificate we receive so we move the fetchIPAddresses function to only execute when a certificate has matched.

(There is also a fix for the tests because the issuer was not present in the fixture files.)